### PR TITLE
Add SQLAlchemy ORM models and DB initialization script

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+sqlalchemy

--- a/scripts/init_db.py
+++ b/scripts/init_db.py
@@ -1,0 +1,62 @@
+"""Create the SQLite database and seed initial activities.
+
+Run this script to create the DB file and tables:
+
+    python scripts/init_db.py
+
+"""
+from pathlib import Path
+from src.db import engine, Base
+from src.models import Activity
+
+def seed_activities(session):
+    # Minimal seed data copied from the existing in-memory app
+    activities = [
+        {
+            "name": "Chess Club",
+            "description": "Learn strategies and compete in chess tournaments",
+            "schedule": "Fridays, 3:30 PM - 5:00 PM",
+            "max_participants": 12,
+        },
+        {
+            "name": "Programming Class",
+            "description": "Learn programming fundamentals and build software projects",
+            "schedule": "Tuesdays and Thursdays, 3:30 PM - 4:30 PM",
+            "max_participants": 20,
+        },
+        {
+            "name": "Gym Class",
+            "description": "Physical education and sports activities",
+            "schedule": "Mondays, Wednesdays, Fridays, 2:00 PM - 3:00 PM",
+            "max_participants": 30,
+        },
+    ]
+
+    for a in activities:
+        exists = session.query(Activity).filter_by(name=a["name"]).first()
+        if not exists:
+            act = Activity(
+                name=a["name"],
+                description=a.get("description"),
+                schedule=a.get("schedule"),
+                max_participants=a.get("max_participants"),
+            )
+            session.add(act)
+    session.commit()
+
+
+def main():
+    # Ensure DB directory
+    db_path = Path("./mcp.db")
+    Base.metadata.create_all(bind=engine)
+    from src.db import SessionLocal
+    session = SessionLocal()
+    try:
+        seed_activities(session)
+        print("Database initialized and seed data added (if missing).")
+    finally:
+        session.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/db.py
+++ b/src/db.py
@@ -1,0 +1,18 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, declarative_base
+import os
+
+# SQLite URL by default; can be overridden by env var DATABASE_URL
+DATABASE_URL = os.getenv("DATABASE_URL", "sqlite:///./mcp.db")
+
+# For SQLite we need check_same_thread=False for the default driver when using threads
+engine = create_engine(DATABASE_URL, connect_args={"check_same_thread": False})
+SessionLocal = sessionmaker(bind=engine, autocommit=False, autoflush=False)
+Base = declarative_base()
+
+def get_db():
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,34 @@
+from sqlalchemy import Column, String, Integer, Text, ForeignKey, DateTime
+from sqlalchemy.orm import relationship
+from .db import Base
+import datetime
+
+
+class Activity(Base):
+    __tablename__ = "activities"
+    name = Column(String, primary_key=True, index=True)
+    description = Column(Text, nullable=True)
+    schedule = Column(String, nullable=True)
+    max_participants = Column(Integer, nullable=True)
+    # relationships
+    participants = relationship("Enrollment", back_populates="activity", cascade="all, delete-orphan")
+
+
+class Student(Base):
+    __tablename__ = "students"
+    email = Column(String, primary_key=True, index=True)
+    name = Column(String, nullable=False)
+    grade = Column(String, nullable=True)
+    admission_no = Column(String, nullable=True)
+    photo = Column(String, nullable=True)
+    enrollments = relationship("Enrollment", back_populates="student", cascade="all, delete-orphan")
+
+
+class Enrollment(Base):
+    __tablename__ = "enrollments"
+    id = Column(Integer, primary_key=True, index=True)
+    activity_name = Column(String, ForeignKey("activities.name"))
+    student_email = Column(String, ForeignKey("students.email"))
+    timestamp = Column(DateTime, default=datetime.datetime.utcnow)
+    activity = relationship("Activity", back_populates="participants")
+    student = relationship("Student", back_populates="enrollments")


### PR DESCRIPTION
This PR adds a minimal SQLAlchemy setup with ORM models for Activity, Student and Enrollment, plus a `scripts/init_db.py` script to create the SQLite database (`mcp.db`) and seed initial activities.

Files added:
- `src/db.py` — engine, session and Base
- `src/models.py` — Activity, Student, Enrollment models
- `scripts/init_db.py` — creates tables and seeds some activities
- `requirements.txt` — adds `sqlalchemy`

Notes:
- This is the first step to enable persistent storage. The FastAPI app is not yet wired to use these models — that will be done in follow-up PR(s) which implement CRUD endpoints and migrations.
- To initialize the DB locally: `python scripts/init_db.py`

Reviewers: please verify models and naming. Once approved I will proceed to implement the endpoints and tests.